### PR TITLE
Introduce filter to disable style enqueue

### DIFF
--- a/new-badge.php
+++ b/new-badge.php
@@ -81,7 +81,9 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 
 			// Setup styles
 			function setup_styles() {
-				wp_enqueue_style( 'nb-styles', plugins_url( '/assets/css/style.css', __FILE__ ) );
+				if ( apply_filters( 'woocommerce_new_badge_enqueue_styles', true ) ) {
+					wp_enqueue_style( 'nb-styles', plugins_url( '/assets/css/style.css', __FILE__ ) );
+				}
 			}
 
 


### PR DESCRIPTION
Rather than recommending to dequeue the styles (as [recommended in the FAQ](https://github.com/jameskoster/woocommerce-new-product-badge/blob/master/readme.txt#L27)), I'd like to have a filter to do this. :smile:
