### PR TITLE
Added localization compatibility with WPML

### DIFF
--- a/new-badge.php
+++ b/new-badge.php
@@ -20,9 +20,12 @@ Domain Path: /languages/
 if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) ) ) {
 
 	/**
-	 * Localisation
+	 * Localisation (with WPML support)
 	 **/
-	load_plugin_textdomain( 'woocommerce-new-badge', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
+	add_action( 'init', 'plugin_init' );
+	function plugin_init() {
+		load_plugin_textdomain( 'woocommerce-new-badge', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+	}
 
 
 	/**


### PR DESCRIPTION
If the language is changed via WPML, the plugin loads the translation for that language, instead of the one defined by WPLANG.
